### PR TITLE
Change range values on drag instead of on release

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -84,7 +84,7 @@ browser.tabs.query({ currentWindow: true, active: true }).then(tabs => {
 			const gain = node.querySelector('.element-gain')
 			gain.value = settings.gain || 1
 			gain.parentElement.querySelector('.target').textContent = '' + gain.value
-			gain.addEventListener('change', _ => {
+			gain.addEventListener('input', _ => {
 				applySettings(fid, elid, { gain: gain.value })
 				gain.title = '' + gain.value
 				gain.parentElement.querySelector('.target').textContent = '' + gain.value
@@ -92,7 +92,7 @@ browser.tabs.query({ currentWindow: true, active: true }).then(tabs => {
 			const pan = node.querySelector('.element-pan')
 			pan.value = settings.pan || 0
 			pan.parentElement.querySelector('.target').textContent = '' + pan.value
-			pan.addEventListener('change', _ => {
+			pan.addEventListener('input', _ => {
 				applySettings(fid, elid, { pan: pan.value })
 				pan.title = '' + pan.value
 				pan.parentElement.querySelector('.target').textContent = '' + pan.value


### PR DESCRIPTION
First off, big thank you for the extension! Albeit being simple it's a game changer for listening to music in meetings for me :).

Currently, the gain and pan are set when the slider is released - which makes it hard for me to get my most of the time desired value of 0.05.
This PR changes the used event on the sliders from "change" to "input" which instead fires on dragging the slider.
This makes it much easier to find the fitting volume setting.

Would be glad if this change could be merged.